### PR TITLE
Add ColumnTypeMapper.FindExplicitConstructor()

### DIFF
--- a/Dapper.ColumnMapper/ColumnTypeMapper.cs
+++ b/Dapper.ColumnMapper/ColumnTypeMapper.cs
@@ -25,6 +25,11 @@ namespace Dapper.ColumnMapper
         {
             return _internalMapper.FindConstructor(names, types);
         }
+        
+        public ConstructorInfo FindExplicitConstructor()
+        {
+            return _internalMapper.FindExplicitConstructor();
+        }
 
         public SqlMapper.IMemberMap GetConstructorParameter(ConstructorInfo constructor, string columnName)
         {


### PR DESCRIPTION
SqlMapper.ITypeMap has added a new method, FindExplicitConstructor. The latest Dapper package breaks ColumnMapper since it no longer implements the interface correctly.

This pull request adds and implements that function.
